### PR TITLE
enclose temperature param in exponential expression, uniform sampling routine

### DIFF
--- a/src/lib/functions.ml
+++ b/src/lib/functions.ml
@@ -177,7 +177,7 @@ let t_lookup alpha_level dgf =
 let softmax ?(temp=1.0) weights =
   if Array.length weights = 0 then raise (Invalid_argument "weights") else
   if temp = 0.0 then raise (Invalid_argument "temp") else
-    let weights = Array.map (fun w -> exp w /. temp) weights in
+    let weights = Array.map (fun w -> exp (w /. temp)) weights in
     let sum = Array.fold_left (+.) 0.0 weights in
     let weights = Array.map (fun w -> w /. sum) weights in
     Array.get weights

--- a/src/lib/sampling.ml
+++ b/src/lib/sampling.ml
@@ -27,6 +27,15 @@ let normal ?seed ~mean ~std () =
   let rsn = normal_std ?seed () in
   (fun () -> std *. (rsn ()) +. mean)
 
+let uniform ?seed n =
+  if n <= 0 then raise (Invalid_argument "n") else
+  let r =
+    match seed with
+    | None   -> Random.State.make_self_init ()
+    | Some a -> Random.State.make a
+  in
+  fun () -> Random.State.int r n
+
 let multinomial ?seed weights =
   let sum = Array.sumf weights in
   if Util.significantly_different_from 1.0 sum then

--- a/src/lib/sampling.mli
+++ b/src/lib/sampling.mli
@@ -8,6 +8,13 @@ val normal : ?seed:int array -> mean:float -> std:float -> unit -> (unit ->
 (** [normal_std seed ()] is equivalent to [normal seed ~mean:0.0 ~std:1.0 ()].*)
 val normal_std : ?seed:int array -> unit -> (unit -> float)
 
+(** [uniform ?seed n] creates a generator that will return an integer
+    representating the ith element of [n] possible elements from
+    the uniformly random distribution.
+
+    @raise Invalid_argument if [n] is zero or negative. *)
+val uniform : ?seed:int array -> int -> (unit -> int)
+
 (** [multinomial ?seed weights] creates a generator that will return an integer
     representating the ith element from the Multinomial distribution given by
     a [weights] vector which sums to [1].


### PR DESCRIPTION
Added missing parentheses to scope the temperature parameter properly.
