### PR TITLE
polymorphic sampling module

### DIFF
--- a/src/lib/sampling.ml
+++ b/src/lib/sampling.ml
@@ -57,3 +57,22 @@ let multinomial ?seed weights =
 let softmax ?seed ?temp weights =
   let f = Functions.softmax ?temp weights in
   multinomial ?seed (Array.init (Array.length weights) f)
+
+module Poly =
+  struct
+    let uniform ?seed elems =
+      let f = uniform ?seed (Array.length elems) in
+      fun () -> elems.(f())
+
+    let multinomial ?seed elems weights =
+      if (Array.length elems != Array.length weights) then
+        raise (Invalid_argument "weights") else
+          let f = multinomial ?seed weights in
+          fun () -> elems.(f())
+
+    let softmax ?seed ?temp elems weights =
+      if (Array.length elems != Array.length weights) then
+        raise (Invalid_argument "weights") else
+          let f = softmax ?seed weights in
+          fun () -> elems.(f())
+  end

--- a/src/lib/sampling.mli
+++ b/src/lib/sampling.mli
@@ -28,3 +28,30 @@ val multinomial : ?seed:int array -> float array -> (unit -> int)
 
     @raise Invalid_argument if [weights] is empty *)
 val softmax : ?seed:int array -> ?temp:float -> float array -> (unit -> int)
+
+(** Provides polymorphic versions that sample over arrays of any type *)
+module Poly :
+  sig
+    (** [uniform ?seed elems] creates a generator that will sample from the
+        [elems] array using the uniformly random distribution.
+
+        @raise Invalid_argument if the given element array is empty. *)
+    val uniform : ?seed:int array -> 'a array -> (unit -> 'a)
+
+    (** [multinomial ?seed elems weights] creates a generator will sample from
+        the [elems] array using Multinomial distribution given by
+        a [weights] vector which sums to [1].
+
+        @raise Invalid_argument if [weights] do not sum to [1.0] or
+        the length of the [elems] and [weights] arrays are not equal. *)
+    val multinomial : ?seed:int array -> 'a array -> float array -> (unit -> 'a)
+
+    (** [softmax ?seed ?temp elems weights] creates a generator that will
+        sample from the [elems] array using the softmax distribution given by
+        a [weights] vector and [temp]erature parameter which defaults to [1.0].
+
+        @raise Invalid_argument if [weights] is empty or the length of the
+        [elems] and [weights] arrays are not equal. *)
+    val softmax : ?seed:int array -> ?temp:float ->'a array ->
+      float array -> (unit -> 'a)
+  end


### PR DESCRIPTION
I didn't see value in a functor for this solution, at least not yet.

How do you think the inputs should be passed to these functions? I went with two arrays that are validated to be the same length, but perhaps one array of 'a \* float would be safer.

Another possibility is to take in a function like 'a -> float but since it would have to be normalized for most algorithms you lose the ability to validate the domain before returning a sampler.

Also, I'd like to write tests for these functions if the harness is ready.
