### PR TITLE
add lacaml as opam dependency

### DIFF
--- a/opam
+++ b/opam
@@ -11,4 +11,4 @@ build: [
   [make "install"]
 ]
 remove: ["ocamlfind" "remove" "oml"]
-depends: "ocamlfind" {build}
+depends: ["ocamlfind" "lacaml" {build}]


### PR DESCRIPTION
This gets rid of `Undefined global reference: Lacaml_D` error when loading the library through `ocamlfind`.
