### PR TITLE
provide optional sample size argument to Running module functions

### DIFF
--- a/src/lib/running.ml
+++ b/src/lib/running.ml
@@ -22,31 +22,32 @@ let empty = { size   = 0
             ; var    = nan
             }
 
-let init o = { size   = 1
+let init ?(size=1) o = { size
              ; last   = o
              ; max    = o
              ; min    = o
-             ; sum    = o
-             ; sum_sq = o *. o
+             ; sum    = o *. float size
+             ; sum_sq = o *. o *. float size
              ; mean   = o
              ; var    = 0.0
              }
 
-let update t v =
+let update2 t ?(size=1) v =
   if t.size = 0
-  then init v
-  else let n_sum = t.sum +. v in
-       let n_sum_sq = t.sum_sq +. v *. v in
-       let n_size = float t.size +. 1.0 in
+  then init ~size v
+  else let size_f = float size in
+       let n_sum = t.sum +. size_f *. v in
+       let n_sum_sq = t.sum_sq +. size_f *. v *. v in
+       let n_size = float t.size +. size_f in
        let n_mean = n_sum /. n_size in
        let n_var =
          let num = n_sum_sq
                  -. 2.0 *. n_mean *. n_sum
-                 +. n_size *. n_mean *.  n_mean
+                 +. n_size *. n_mean *. n_mean
          and den = n_size -. 1.0 in
          num /. den
       in
-      { size   = t.size + 1
+      { size   = t.size + size
       ; last   = v
       ; max    = max t.max v
       ; min    = min t.min v
@@ -55,6 +56,8 @@ let update t v =
       ; mean   = n_mean
       ; var    = n_var
       }
+
+let update t v = update2 t ~size:1 v
 
 let join rs1 rs2 =
   if rs1.size = 0

--- a/src/lib/running.ml
+++ b/src/lib/running.ml
@@ -32,7 +32,7 @@ let init ?(size=1) o = { size
              ; var    = 0.0
              }
 
-let update2 t ?(size=1) v =
+let update ?(size=1) t v =
   if t.size = 0
   then init ~size v
   else let size_f = float size in
@@ -56,8 +56,6 @@ let update2 t ?(size=1) v =
       ; mean   = n_mean
       ; var    = n_var
       }
-
-let update t v = update2 t ~size:1 v
 
 let join rs1 rs2 =
   if rs1.size = 0

--- a/src/lib/running.mli
+++ b/src/lib/running.mli
@@ -16,13 +16,9 @@ val empty : t
     which defaults to [1]. *)
 val init : ?size:int -> float -> t
 
-(** [update t x] incorporate [x] with [1] sample into the
-    statistics tracked in [t]. *)
-val update : t -> float -> t
-
-(** [update2 t ?size x] incorporate [x] with [size] default to [1] sample(s)
+(** [update t ?size x] incorporate [x] with [size] (defaulting to [1]) samples
     into the statistics tracked in [t]. *)
-val update2 : t -> ?size:int -> float -> t
+val update : ?size:int -> t -> float -> t
 
 (** [join t1 t2] return a [Running.t] if you had first observed the elements
     by [t1] and then [t2]. *)

--- a/src/lib/running.mli
+++ b/src/lib/running.mli
@@ -12,11 +12,17 @@ type t = { size : int         (** Number of observations. *)
 (** [empty] an empty [t], useful for initializing the fold. *)
 val empty : t
 
-(** [init x] initializes a [t] with [x]. *)
-val init : float -> t
+(** [init ?size x] initializes a [t] with [x] and initial [size]
+    which defaults to [1]. *)
+val init : ?size:int -> float -> t
 
-(** [update t x] incorporate [x] into the statistics tracked in [t]. *)
+(** [update t x] incorporate [x] with [1] sample into the
+    statistics tracked in [t]. *)
 val update : t -> float -> t
+
+(** [update2 t ?size x] incorporate [x] with [size] default to [1] sample(s)
+    into the statistics tracked in [t]. *)
+val update2 : t -> ?size:int -> float -> t
 
 (** [join t1 t2] return a [Running.t] if you had first observed the elements
     by [t1] and then [t2]. *)

--- a/src/lib/running.mli
+++ b/src/lib/running.mli
@@ -16,7 +16,7 @@ val empty : t
     which defaults to [1]. *)
 val init : ?size:int -> float -> t
 
-(** [update t ?size x] incorporate [x] with [size] (defaulting to [1]) samples
+(** [update ?size t x] incorporate [x] with [size] (defaulting to [1]) samples
     into the statistics tracked in [t]. *)
 val update : ?size:int -> t -> float -> t
 

--- a/src/lib/running.mlt
+++ b/src/lib/running.mlt
@@ -41,7 +41,8 @@ let () =
     roughly_equal ~order_comp:1e13 rs.var dv
   in
   let compare_rs rs1 rs2 =
-    (* Printf.printf "%f vs %f \n" rs1.var rs2.var; *)
+    (* Printf.printf "[mean] %f vs %f \n" rs1.mean rs2.mean; *)
+    (* Printf.printf "[var] %f vs %f \n" rs1.var rs2.var; *)
     rs1.size = rs2.size &&
     equal_floats rs1.last rs2.last &&
     equal_floats rs1.max rs2.max &&
@@ -93,6 +94,18 @@ let () =
       let rs_data   = Array.fold_left update empty data in
       let rs_joined = join rs_left rs_right in
       compare_rs rs_data rs_joined)
+    Spec.([just_postcond_pred is_true]);
+
+  Test.add_random_test
+    ~title:"Running: sampling with variable sizes using update2"
+    ~nb_runs:1000
+    Gen.(zip2 (make_int 1 max_array_size) (array_float max_array_size))
+    (fun (index, data) ->
+      let left = Array.sub data 0 index in
+      let left_1 = Array.fold_left update empty left in
+      let left_1' = Array.fold_left update left_1 left in
+      let left_2 = Array.fold_left (update2 ~size:2) empty left in
+      compare_rs left_1' left_2)
     Spec.([just_postcond_pred is_true]);
 
   ()

--- a/src/lib/running.mlt
+++ b/src/lib/running.mlt
@@ -97,14 +97,14 @@ let () =
     Spec.([just_postcond_pred is_true]);
 
   Test.add_random_test
-    ~title:"Running: sampling with variable sizes using update2"
+    ~title:"Running: variable sizes using update"
     ~nb_runs:1000
     Gen.(zip2 (make_int 1 max_array_size) (array_float max_array_size))
     (fun (index, data) ->
       let left = Array.sub data 0 index in
       let left_1 = Array.fold_left update empty left in
       let left_1' = Array.fold_left update left_1 left in
-      let left_2 = Array.fold_left (update2 ~size:2) empty left in
+      let left_2 = Array.fold_left (update ~size:2) empty left in
       compare_rs left_1' left_2)
     Spec.([just_postcond_pred is_true]);
 


### PR DESCRIPTION
This is a minor but important change for me that provides the ability to the specify the size of an observation in addition to its value. 

I didn't want to break the ability to pass `update` to fold functions as is, so I made a sister function `val update2 : t -> ?size:int -> float -> t` which takes the additional parameter. The `init` method has been extended to take the `?size:int` parameter as well.

I added a test for this which passes most of the time but occasionally diverges past the allowed tolerance (this happens for some other `Running` tests so I think it's permissible).
