### PR TITLE
add lacaml to META requires

### DIFF
--- a/META
+++ b/META
@@ -1,5 +1,5 @@
 description="OCaml Math Library"
-requires=""
+requires="lacaml"
 version="0.0.1"
 directory="."
 archive(byte)="oml.cma"


### PR DESCRIPTION
Found another place where we need to export lacaml as an explicit dependency.
