### PR TITLE
Pluggable mean update rule

### DIFF
--- a/src/lib/running.mli
+++ b/src/lib/running.mli
@@ -9,6 +9,13 @@ type t = { size : int         (** Number of observations. *)
          ; var : float        (** _Unbiased_ variance. *)
          }
 
+(** Defines a mean update function. Given an existing running
+    statistic [t], an option sample [size], the already computed
+    updated statistics [n_sum], [num_sum_sq], and [n_size], finally
+    with the newly observed value, return a new estimate of the mean. *)
+type mean_update = ?size:int -> n_sum:float ->
+  n_sum_sq:float -> n_size:float -> t -> float -> float
+
 (** [empty] an empty [t], useful for initializing the fold. *)
 val empty : t
 
@@ -16,9 +23,10 @@ val empty : t
     which defaults to [1]. *)
 val init : ?size:int -> float -> t
 
-(** [update ?size t x] incorporate [x] with [size] (defaulting to [1]) samples
-    into the statistics tracked in [t]. *)
-val update : ?size:int -> t -> float -> t
+(** [update ?size ?mean_update t x] incorporate [x] with given [size]
+    (defaulting to [1]) and mean update rule [mean_update] (defaulting
+    to unbiased) into the statistics tracked in [t]. *)
+val update : ?size:int -> ?mean_update:mean_update -> t -> float -> t
 
 (** [join t1 t2] return a [Running.t] if you had first observed the elements
     by [t1] and then [t2]. *)


### PR DESCRIPTION
Sometimes we want to compute a running statistic using an alternate estimator for the mean (eg. Q-learning, hard coded step parameters, temperature based, etc).

This factors out the mean update rule into a function which can optionally be specified by the user in the `update`  function. It defaults to the standard unbiased mean estimator, as before.
