### PR TITLE
add mean_update to join, introduce var_update param

### DIFF
--- a/src/lib/running.mli
+++ b/src/lib/running.mli
@@ -9,12 +9,18 @@ type t = { size : int         (** Number of observations. *)
          ; var : float        (** _Unbiased_ variance. *)
          }
 
-(** Defines a mean update function. Given an existing running
-    statistic [t], number of samples [size], the already computed
-    updated statistics [n_sum], [num_sum_sq], and [n_size], finally
-    with the newly observed value, return a new estimate of the mean. *)
+(** Defines a mean update function. Given an existing running statistic [t],
+    number of samples [size], the already computed updated statistics
+    [n_sum], [n_sum_sq], [n_size], and the newly observed value, return
+    a new estimate of the mean. *)
 type mean_update = size:int -> n_sum:float ->
   n_sum_sq:float -> n_size:float -> t -> float -> float
+
+(** Defines a variance update function. Given an existing running
+    statistic [t], the already computed updated statistics [n_mean]
+    [n_sum], [n_sum_sq], and [n_size], return a new estimate of the variance. *)
+type var_update = n_mean:float -> n_sum:float ->
+  n_sum_sq:float -> n_size:float -> t -> float
 
 (** [empty] an empty [t], useful for initializing the fold. *)
 val empty : t
@@ -23,11 +29,12 @@ val empty : t
     which defaults to [1]. *)
 val init : ?size:int -> float -> t
 
-(** [update ?size ?mean_update t x] incorporate [x] with given [size]
-    (defaulting to [1]) and mean update rule [mean_update] (defaulting
+(** [update ?size ?mean_update ?var_update t x] incorporate [x] with given [size]
+    (defaulting to [1]) and update rules [mean_update], [var_update] (defaulting
     to unbiased) into the statistics tracked in [t]. *)
-val update : ?size:int -> ?mean_update:mean_update -> t -> float -> t
+val update : ?size:int -> ?mean_update:mean_update ->  ?var_update:var_update -> t -> float -> t
 
-(** [join t1 t2] return a [Running.t] if you had first observed the elements
-    by [t1] and then [t2]. *)
-val join : t -> t -> t
+(** [join ?mean_update ?var_update t1 t2] return a [Running.t] if you had
+    first observed the elements by [t1] and then [t2] using update rules
+    [mean_update] and [var_update] (defaulting to unbiased) *)
+val join : ?mean_update:mean_update -> ?var_update:var_update -> t -> t -> t

--- a/src/lib/running.mlt
+++ b/src/lib/running.mlt
@@ -1,4 +1,3 @@
-
 open Util
 open Test_utils
 


### PR DESCRIPTION
This makes `Running.join` consistent with `Running.update` for alternative mean update rules. I also factored out the variance update rule so it's reusable in both `Running.join` and `Running.update`. Finally, I exposed the variance update rule as a pluggable entity, just like the mean update rule.

I think one future improvement here which isn't too disruptive is to functorize the rules out of the function signatures and create the original version of `Running` by instantiating a functor using the default rules. Is this a little less invasive than the current approach?
