### PR TITLE
Fix lacaml label compiler error, add lbfgs to .merlin

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -2,4 +2,4 @@ PKG kaputt
 S ./src/lib
 B _build/**
 B _driver/**
-PKG lacaml
+PKG lacaml lbfgs

--- a/src/lib/classify.ml
+++ b/src/lib/classify.ml
@@ -223,7 +223,7 @@ module Log_reg = struct
         let yi = fy.(i) in
         let e  = exp(-. yi *. LD.dot w x.(i)) in
         s := !s +. log1p e;
-        LD.axpy x.(i) ~alpha:(yi *. e /. (1. +. e)) g;
+        LD.axpy x.(i) ~alpha:(yi *. e /. (1. +. e)) ~x:g;
       done;
       -. !s -. 0.5 *. lambda *. LD.dot w w)
 


### PR DESCRIPTION
Master did not compile without these changes (using lacaml version 7.2.1)
