### PR TITLE
Fix Distribution commentary bug

### DIFF
--- a/src/lib/descriptive.ml
+++ b/src/lib/descriptive.ml
@@ -114,7 +114,7 @@ let classify_kurtosis arr =
   else if s > 1.0 then `Slightly_fat
   else `Normal
 
-type commentary =
+type summary =
   { size     : int
   ; min      : float
   ; max      : float
@@ -125,16 +125,16 @@ type commentary =
   ; kurtosis : float * kurtosis_classification
   }
 
-let unbiased_commentary arr =
+let unbiased_summary arr =
   let v = unbiased_var arr in
   let s = unbiased_skew arr in
   let k = unbiased_kurtosis arr in
   let sc = classify_skew arr in
   let kc = classify_kurtosis arr in
   { size     = Array.length arr
-  ; min      = mean arr
-  ; max      = Array.min arr
-  ; mean     = Array.max arr
+  ; min      = Array.min arr
+  ; max      = Array.max arr
+  ; mean     = mean arr
   ; std      = sqrt (unbiased_var arr)
   ; var      = v
   ; skew     = s, sc

--- a/src/lib/descriptive.mli
+++ b/src/lib/descriptive.mli
@@ -128,7 +128,7 @@ type kurtosis_classification =
 val classify_kurtosis : float array -> kurtosis_classification
 
 (** Common statistics that describe data. *)
-type commentary =
+type summary =
   { size     : int
   ; min      : float
   ; max      : float
@@ -139,8 +139,8 @@ type commentary =
   ; kurtosis : float * kurtosis_classification
   }
 
-(** [unbiased_commentary data] summarizes [data] into a [commentary]. *)
-val unbiased_commentary : float array -> commentary
+(** [unbiased_summary data] summarizes [data] into a [summary]. *)
+val unbiased_summary : float array -> summary
 
 (** [histogram data width_setting] group [data] into a specific number of buckets
     of given width (according to [width_setting]:

--- a/src/lib/descriptive.mlt
+++ b/src/lib/descriptive.mlt
@@ -155,8 +155,23 @@ let () =
       let _ = kurtosis_standard_error data in
       let _ = classify_skew data in
       let _ = classify_kurtosis data in
-      let _ = unbiased_commentary data in
       true)
+    Spec.([just_postcond_pred is_true]);
+
+  (* Just a regression test to make sure we don't break the 1-1. *)
+  Test.add_random_test
+    ~title:"Descriptive: unbaised_summary is just that."
+    test_data
+    (fun data ->
+      let s = unbiased_summary data in
+      s.size      = Array.length data &&
+      s.min       = Array.min data &&
+      s.max       = Array.max data &&
+      s.mean      = mean data &&
+      s.std       = sqrt (unbiased_var data) &&
+      s.var       = unbiased_var data &&
+      s.skew      = (unbiased_skew data, classify_skew data) &&
+      s.kurtosis  = (unbiased_kurtosis data, classify_kurtosis data))
     Spec.([just_postcond_pred is_true]);
 
   Test.add_random_test

--- a/src/lib/inference.mli
+++ b/src/lib/inference.mli
@@ -2,7 +2,7 @@
 (** When we do not know the mean or standard deviation of a distribution
     we can still create a prediction interval based off distribution stat.
 *)
-val prediction_interval : float -> Descriptive.commentary -> float * float
+val prediction_interval : float -> Descriptive.summary -> float * float
 
 (** A hypothesis test. *)
 type test =


### PR DESCRIPTION
- Typo in mean/min confusion.
- Renamed structure to summary as opposed to commentary.
