### PR TITLE
Use bisect_ppx in fast mode for coverage.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@
 DRIVER_BUILD_DIR=_driver
 PACKAGES=lacaml lbfgs ocephes
 PACKAGES_TEST=$(PACKAGES) kaputt
-PACKAGES_COVERED=$(PACKAGES_TEST) bisect_ppx
-PACKAGES_INSTALL=$(subst .,-,$(PACKAGES_COVERED))
+PACKAGES_COVERED=$(PACKAGES_TEST) bisect_ppx.fast
+PACKAGES_INSTALL=$(PACKAGES_TEST) bisect_ppx
 
 .PHONY: all clean build install uninstall setup default
 

--- a/tools/travis_ci_test.sh
+++ b/tools/travis_ci_test.sh
@@ -65,7 +65,6 @@ git config --global user.email "you@example.com"
 git config --global user.name "Your Name"
 
 echo Installing Libraries
-opam pin add bisect_ppx https://github.com/rleonid/bisect_ppx.git#fast_works_again
 make setup
 
 echo Compiling

--- a/tools/travis_ci_test.sh
+++ b/tools/travis_ci_test.sh
@@ -65,7 +65,7 @@ git config --global user.email "you@example.com"
 git config --global user.name "Your Name"
 
 echo Installing Libraries
-opam install oasis  # needed for LBFGS
+opam pin add bisect_ppx https://github.com/rleonid/bisect_ppx.git#fast_works_again
 make setup
 
 echo Compiling
@@ -75,7 +75,6 @@ echo Testing
 make covered_test
 
 echo PostingCoverage
-opam pin add ocveralls https://github.com/rleonid/ocveralls.git
 opam install ocveralls
 
 cd _driver


### PR DESCRIPTION
Currently, tests in coverage mode take about 5 min to run on my Mac laptop and sometimes over 10 on `Travis` To speed this up a big, I've fixed up the fast mode of `bisect_ppx` and this patch would switch `oml` over to that mode.
