### PR TITLE
Refactor Optional arg and Regression interface.

### DIFF
--- a/src/lib/classify.mli
+++ b/src/lib/classify.mli
@@ -109,7 +109,7 @@ module type Classifier_intf = sig
   (** Representing training data. *)
   type samples = (clas * feature) list
 
-  (** [estimate spec classes samples] estimates a classifier based upon the
+  (** [estimate opt classes samples] estimates a classifier based upon the
       training [samples].
 
       [classes] is an optional argument to specify ahead of time the possible
@@ -117,14 +117,14 @@ module type Classifier_intf = sig
       This is useful for models where we know the population domain but may
       not see an example of a training datum for rare cases.
 
-      [spec] are the optional classifier dependent estimation/evaluation
+      [opt] are the optional classifier dependent estimation/evaluation
       arguments.
 
       @raise Invalid_argument if [classes] are specified and new ones are
       found in the training [samples].
       @raise Invalid_argument if [samples] is empty.
   *)
-  val estimate : ?spec:spec -> ?classes:clas list -> samples -> t
+  val estimate : ?opt:opt -> ?classes:clas list -> samples -> t
 end
 
 (** A generative classifier builds models of the form
@@ -172,7 +172,7 @@ type binomial_spec =
   classifier on data encoded using
   {{!modtype:Dummy_encoded_data_intf}Dummy variables.} *)
 module BinomialNaiveBayes(D: Dummy_encoded_data_intf) :
-  Generative_intf with type spec = binomial_spec
+  Generative_intf with type opt = binomial_spec
                   and type feature = D.feature
                   and type clas = D.clas
 
@@ -181,7 +181,7 @@ module BinomialNaiveBayes(D: Dummy_encoded_data_intf) :
   classifier on data encoded using
   {{!modtype:Category_encoded_data_intf}Categorical variables.} *)
 module CategoricalNaiveBayes(D: Category_encoded_data_intf) :
-  Generative_intf with type spec = smoothing
+  Generative_intf with type opt = smoothing
                   and type feature = D.feature
                   and type clas = D.clas
 
@@ -191,7 +191,7 @@ module CategoricalNaiveBayes(D: Category_encoded_data_intf) :
   for each of the quantitative features in the
   {{!modtype:Continuous_encoded_data_intf}encoded data}. *)
 module GaussianNaiveBayes(D: Continuous_encoded_data_intf) :
-  Generative_intf with type spec = unit
+  Generative_intf with type opt = unit
                   and type feature = D.feature
                   and type clas = D.clas
 
@@ -230,7 +230,7 @@ type log_reg_spec =
 *)
 module LogisticRegression(D: Continuous_encoded_data_intf) :
   sig
-    include Classifier_intf with type spec = log_reg_spec
+    include Classifier_intf with type opt = log_reg_spec
                             and type feature = D.feature
                             and type clas = D.clas
 
@@ -259,7 +259,7 @@ module LogisticRegression(D: Continuous_encoded_data_intf) :
 *)
 module MulticlassLogisticRegression(D: Continuous_encoded_data_intf) :
   sig
-    include Classifier_intf with type spec = log_reg_spec
+    include Classifier_intf with type opt = log_reg_spec
                              and type feature = D.feature
                              and type clas = D.clas
 

--- a/src/lib/classify.mlt
+++ b/src/lib/classify.mlt
@@ -58,7 +58,7 @@ let () =
           let size = 5
         end)
       in
-      let naiveb = NB.estimate ~spec:{NB.default with bernoulli = true } data in
+      let naiveb = NB.estimate ~opt:{NB.default with bernoulli = true } data in
       let sample = [ `shortbread ; `whiskey; `porridge  ] in
       let result = NB.eval naiveb sample in
       let expect =

--- a/src/lib/regression.mlt
+++ b/src/lib/regression.mlt
@@ -31,12 +31,8 @@ let looe_manually lambda pred resp =
   pred
   |> Array.mapi (fun i p ->
     let p_pred, p_resp = without i in
-    let ms =
-      { add_constant_column = false
-      ; lambda_spec = Some (Spec lambda)
-      }
-    in
-    let model = M.regress ~spec:ms p_pred ~resp:p_resp in
+    let opt   = M.opt ~add_constant_column:false ~l2_regularizer:(`S lambda) () in
+    let model = M.regress ~opt p_pred ~resp:p_resp in
     resp.(i) -. M.eval model p)
 
 (* Testing the accuracy of numerical algorithms is hard (and fun).
@@ -131,7 +127,7 @@ let () =
     ~title:"General can recover coefficients."
     Gen.(general_model 1e11 ~max_samples ~max_predictors)
     (fun (pred, coef, resp) ->
-      let glm = M.regress ~resp pred in
+      let glm = M.(regress ~opt:(opt ~add_constant_column:false ()) ~resp pred) in
       Vectors.equal ~d:1e-2 (M.coefficients glm) coef)
     Spec.([just_postcond_pred is_true]);
 
@@ -142,7 +138,7 @@ let () =
       let glm = M.regress ~resp pred in
       let r0 = (M.residuals glm).(0) in
       let e0 = resp.(0) -. M.eval glm pred.(0) in
-      (*Printf.printf "%.20f\t%.20f\t%b\t%b\n" r0 e0 (r0 = e0) (equal_floats ~d:dx r0 e0)*) 
+      (*Printf.printf "%.20f\t%.20f\t%b\t%b\n" r0 e0 (r0 = e0) (equal_floats ~d:dx r0 e0)*)
       equal_floats ~d:1e-6 r0 e0)
     Spec.([just_postcond_pred is_true]);
 
@@ -152,9 +148,9 @@ let () =
     (fun (pred, _, resp) ->
       let glm = M.regress ~resp pred in
       let m = Descriptive.mean resp in
-      let lambda = Spec (m *. m) in    (* has to be big enough *)
-      let ms = { add_constant_column = false; lambda_spec = Some lambda } in
-      let rdg = M.regress ~spec:ms ~resp pred in
+      let lmd = m *. m in    (* has to be big enough *)
+      let opt = M.opt ~add_constant_column:false ~l2_regularizer:(`S lmd) () in
+      let rdg = M.regress ~opt ~resp pred in
       let rd = Vectors.dot (M.coefficients rdg) (M.coefficients rdg) in
       let gd = Vectors.dot (M.coefficients glm) (M.coefficients glm) in
       rd < gd)
@@ -166,12 +162,12 @@ let () =
     Gen.(general_model 1e11 ~max_samples ~max_predictors)
     (fun (pred, _, resp) ->
       let r,c = Matrices.dim pred in
-      let reg =
+      let tik_matrix =
         Array.init r (fun i -> Array.init c (fun j ->
           if i = j then 1.0 else 0.0))
       in
-      let opt = {regularizer = reg; lambda_spec = None} in
-      let _t  = T.regress ~spec:opt ~resp pred in
+      let opt = T.opt ~tik_matrix () in
+      let _t  = T.regress ~opt ~resp pred in
       true)
     Spec.([just_postcond_pred is_true]);
 

--- a/src/lib/util.ml
+++ b/src/lib/util.ml
@@ -192,8 +192,8 @@ end
 
 module type Optional_arg_intf = sig
 
-  type spec             (** type of default argument. *)
-  val default : spec    (** A default value used when not specified.*)
+  type opt            (** type of default argument. *)
+  val default : opt   (** A default value used when not specified.*)
 end
 
 let fst3 (x,_,_) = x

--- a/src/lib/util.mli
+++ b/src/lib/util.mli
@@ -172,8 +172,8 @@ end
 (** When passing optional arguments to procedures. *)
 module type Optional_arg_intf = sig
 
-  type spec             (** type of default argument. *)
-  val default : spec    (** A default value used when not specified.*)
+  type opt            (** type of default argument. *)
+  val default : opt   (** A default value used when not specified.*)
 end
 
 


### PR DESCRIPTION
- Renamed spec type to usage.
- Created special constructors for regression models to hide the
  optional arguments. Each type is now defined only in that module and
  does not pollute the main Regression module.
- Changed to using polymorphic variants to express regularizers.
