### PR TITLE
Constrain lacaml, lbfgs, and ocephes used for development.

### DIFF
--- a/opam
+++ b/opam
@@ -13,7 +13,7 @@ install: [make "install"]
 remove: ["ocamlfind" "remove" "oml"]
 depends: [
   "ocamlfind" {build}
-  "lacaml"
-  "lbfgs"
-  "ocephes"
+  "lacaml" { = "8.0.6" }
+  "lbfgs" { = "0.8.7" }
+  "ocephes" { = "0.8" }
 ]


### PR DESCRIPTION
For those folks who want to build from source, I'd like to synchronize our dependencies. I've added equality constraints (as strict as possible) because I value making sure that the project always builds above having large constraints (that's for releasing, tagged versions). We should expand these constraints as new versions come out and we verify that the project (the master branch in this case) builds.

This should fix https://github.com/hammerlab/oml/issues/151

@struktured 
