### PR TITLE
Replace invalidArg with invalid_arg

### DIFF
--- a/src/lib/cls/naive_bayes.ml
+++ b/src/lib/cls/naive_bayes.ml
@@ -21,7 +21,6 @@ module D = Statistics.Distributions
 module O = Online
 open Intf
 
-
 let multiply_ref = ref true
 
 (* How we choose to multiply large arrays of small probabilities.
@@ -61,9 +60,9 @@ let eval_naive_bayes ~to_prior ~to_likelihood cls_assoc =
 (* init - init per class data
    update - update per class data
    incorporate - convert class assoc to final shape *)
-let estimate_naive_bayes modulename (type c) init update incorporate
+let estimate_naive_bayes m (type c) init update incorporate
   (module Cm : Map.S with type key = c) ?(classes=[]) (data : (c * 'a) list) =
-  let ia = invalidArg "Classify.%s.estimate: %s" modulename in
+  let ia fmt = invalid_arg ~m ~f:"estimate" fmt in
   if data = [] then
     ia "Nothing to train on"
   else
@@ -82,7 +81,8 @@ let estimate_naive_bayes modulename (type c) init update incorporate
               Cm.add cls (update a ftr) m
             with Not_found ->
               if error_on_new then
-                ia (Printf.sprintf "Unexpected class at datum %d" total)
+                (*ia (Printf.sprintf "Unexpected class at datum %d" total*)
+                ia "Unexpected class at datum %d" total
               else
                 Cm.add cls (update (init cls) ftr) m
           in
@@ -116,7 +116,7 @@ module Binomial(Data: Dummy_encoded_data) = struct
   let safe_encoding f =
     let e = Data.encoding f in
     if Array.any (fun i -> i >= Data.size) e then
-      invalidArg "Binomial.encoding: index beyond the encoding size."
+      invalid_arg ~m:"Binomial" ~f:"encoding" "index beyond the encoding size."
     else
       e
 
@@ -198,9 +198,8 @@ module Categorical(Data: Category_encoded_data) = struct
     if same_size && constrained then
       e
     else
-      invalidArg
-        "Category_encoded_data.encoding: same size %b, constrained: %b"
-          same_size constrained
+      invalid_arg ~m:"Category_encoded_data" ~f:"encoding"
+        "same size %b, constrained: %b" same_size constrained
 
   let class_probabilities t cls =
     let (prior, likelihood_arr) = List.assoc cls t in
@@ -259,9 +258,8 @@ module Gaussian(Data: Continuous_encoded_data) = struct
     if l = Data.size then
       e
     else
-      Util.invalidArg
-        "Continuous_encoded_data.encoding: size %d actual %d"
-          Data.size l
+      invalid_arg ~m:"Continuous_encoded_data" ~f:"encoding"
+        "size %d actual %d" Data.size l
 
   let class_probabilities t cls =
     let (prior, dist_params) = List.assoc cls t in

--- a/src/lib/cls/probabilities.ml
+++ b/src/lib/cls/probabilities.ml
@@ -18,7 +18,7 @@
 type 'a t = ('a * float) list
 
 let most_likely = function
-  | []    -> Util.invalidArg "Classification.most_likely: empty probabilities"
+  | []    -> Util.invalid_arg "Probabilities.most_likely: empty probabilities"
   | h::tl ->
     ListLabels.fold_left ~f:(fun ((_,p1) as c1) ((_,p2) as c2) ->
       if p2 > p1 then c2 else c1) ~init:h tl

--- a/src/lib/rgr/eval_multivariate.ml
+++ b/src/lib/rgr/eval_multivariate.ml
@@ -75,12 +75,14 @@ let eval glm vec =
   let vn = Array.length vec in
   if glm.padded then
     if vn + 1 <> n then
-      invalidArg "Improper array length: %d exp %d - 1." vn n
+      invalid_arg ~m:"Regression" ~f:"eval"
+        "Improper array length: %d exp %d - 1." vn n
     else
       let c = Array.sub coe 1 (n - 1) in
       coe.(0) +. dot c vec
   else if vn <> n then
-    invalidArg "Improper array length: %d exp %d." vn n
+    invalid_arg ~m:"Regression" ~f:"eval"
+      "Improper array length: %d exp %d." vn n
   else
     dot coe vec
 

--- a/src/lib/rgr/interpolate.ml
+++ b/src/lib/rgr/interpolate.ml
@@ -16,10 +16,11 @@
 *)
 
 open Util
+let invalid_arg ~f fmt = invalid_arg ~m:"Interpolate" ~f fmt
 
 let linear (ax, ay) (bx, by) =
   if ax = bx then
-    invalidArg "equal x values %f" ax
+    invalid_arg ~f:"linear" "equal x values %f" ax
   else
     let slope = Float.((by - ay) / (bx - ax)) in
     fun x -> Float.(slope * (x - ax) + ay)
@@ -91,7 +92,7 @@ module Spline = struct
       (fun i ->
         let _x, y, opt = t.(i) in
         match opt with
-        | None -> invalidArg "Improper spline size %d" i
+        | None -> invalid_arg ~f:"coefficients" "improper spline size %d" i
         | Some (c, b, a)  -> y, c, b, a)
 
   (* Helper functions to extract correctly indexed elements of data.
@@ -140,7 +141,7 @@ module Spline = struct
   let fit ?(bc=Natural) arr =
     let n = Array.length arr in
     if n < 3 then
-      invalidArg "Less than 3 data points %d" n;
+      invalid_arg ~f:"fit" "Less than 3 data points %d" n;
     Array.sort (fun (x1,_) (x2,_) -> compare x1 x2) arr;
     let abc, d = setup_tridiagonal bc arr in
     let m = Tri_Diagonal.solve abc d in

--- a/src/lib/rgr/univariate.ml
+++ b/src/lib/rgr/univariate.ml
@@ -67,7 +67,8 @@ let regress ?(opt=default) pred ~resp =
   let weights =
     if an = 0 then Array.make n 1.0
     else if an <> n then
-      invalidArg "regress: opt length %d <> d predictor size %d" an n
+      invalid_arg ~m:"Univariate" ~f:"regress"
+        "opt length %d <> d predictor size %d" an n
     else
       opt
   in

--- a/src/lib/stats/descriptive.ml
+++ b/src/lib/stats/descriptive.ml
@@ -16,6 +16,7 @@
 *)
 
 open Util
+let invalid_arg ~f fmt = invalid_arg ~m:"Descriptive" ~f fmt
 
 (* TODO: A tiny optimization; Once bench mark code has been written, it might
    be useful to compare the logic in this code where variables such as the
@@ -201,7 +202,7 @@ let spearman x y =
   let n = Array.length x in
   let ny = Array.length y in
   if ny <> n then
-    invalidArg "spearman: array lengths don't match %d %d." n ny
+    invalid_arg ~f:"spearman" "array lengths don't match %d %d." n ny
   else
     let rx = Array.ranks ~average_ties:true x in
     let ry = Array.ranks ~average_ties:true y in

--- a/src/lib/unc/matrices.ml
+++ b/src/lib/unc/matrices.ml
@@ -16,6 +16,7 @@
 *)
 
 open Util
+let invalid_arg ~f fmt = invalid_arg ~m:"Matrices" ~f fmt
 
 type t = Vectors.t array
 
@@ -35,8 +36,8 @@ let diagonal ?n ?m v =
   let l = Array.length v in
   let n = match n with | None -> l | Some n -> n in
   let m = match m with | None -> l | Some m -> m in
-  if n <= 0 then invalidArg "Invalid argument n: %d" n else
-    if m <= 0 then invalidArg "Invalid argument m: %d" m else
+  if n <= 0 then invalid_arg ~f:"diagonal" "n: %d" n else
+    if m <= 0 then invalid_arg ~f:"diagonal" "m: %d" m else
       Array.init n (fun r ->
         Array.init m (fun c ->
           if r = c && r < l then v.(r) else 0.0))
@@ -64,8 +65,9 @@ let prod ml mr =
   let row_l, col_l = dim ml
   and row_r, col_r = dim mr in
   if col_l <> row_r then
-    invalidArg "incompatible matrices dimensions (%d, %d)*(%d, %d) for product"
-      row_l col_l row_r col_r
+    invalid_arg ~f:"prod"
+      "incompatible matrices dimensions (%d, %d)*(%d, %d) for product"
+        row_l col_l row_r col_r
   else
     let n = col_l - 1 in
     let s = ref 0.0 in
@@ -80,8 +82,9 @@ let prod ml mr =
 let prod_row_vector v m =
   let col_l = Array.length v and row_r, col_r = dim m in
   if col_l <> col_r then
-    invalidArg "incompatible vector matrix dimensions [%d]*(%d, %d) for prod_row_vector"
-      col_l row_r col_r
+    invalid_arg ~f:"prod_row_vector"
+      "incompatible vector matrix dimensions [%d]*(%d, %d) for prod_row_vector"
+        col_l row_r col_r
   else
     let n = col_l - 1 in
     let s = ref 0.0 in
@@ -95,8 +98,9 @@ let prod_row_vector v m =
 let prod_column_vector m v =
   let row_l, col_l = dim m and row_r = Array.length v in
   if col_l <> row_r then
-    invalidArg "incompatible vector matrix dimensions (%d, %d)*[%d] for prod_column_vector"
-      row_l col_l row_r
+    invalid_arg ~f:"prod_column_vector"
+      "incompatible vector matrix dimensions (%d, %d)*[%d] for prod_column_vector"
+        row_l col_l row_r
   else
     let n = col_l - 1 in
     let s = ref 0.0 in

--- a/src/lib/unc/solvers.ml
+++ b/src/lib/unc/solvers.ml
@@ -16,6 +16,7 @@
 *)
 
 open Util
+let invalid_arg ~f fmt = invalid_arg ~m:"Solvers" ~f fmt 
 
 let newton_raphson_full ?init ~accuracy ~iterations ~lower ~upper ~f ~df =
   let rec loop x i =
@@ -87,7 +88,6 @@ let bisection ~epsilon ~lower ~upper f =
   | `EqZero v
   | `CloseEnough v -> v
   | `Outside _     ->
-      invalidArg "Function does not take oppositely signed values at bounds"
+      invalid_arg ~f:"bisection" "Function does not take oppositely signed values at bounds"
   | `IntermediateValueTheoremViolated v ->
-      invalidArg "Intermediate Value Theorem has been violated: %f" v
-
+      invalid_arg ~f:"bisection" "Intermediate Value Theorem has been violated: %f" v

--- a/src/lib/util/oml_array.ml
+++ b/src/lib/util/oml_array.ml
@@ -17,12 +17,13 @@
 
 include Array
 open Oml_util
+let invalid_arg ~f fmt = invalid_arg ~m:"Array" ~f fmt
 
 let fold2 f i a b =
   let n = Array.length a
   and m = Array.length b in
   if n <> m then
-    invalidArg "unequal lengths %d and %d" n m
+    invalid_arg ~f:"fold2" "unequal lengths %d and %d" n m
   else
     begin
       let r = ref i in
@@ -36,7 +37,7 @@ let map2 f a b =
   let n = Array.length a
   and m = Array.length b in
   if n <> m then
-    invalidArg "unequal lengths %d and %d" n m
+    invalid_arg ~f:"map2" "unequal lengths %d and %d" n m
   else
     Array.mapi (fun i a_i -> f a_i b.(i)) a
 
@@ -129,7 +130,7 @@ let ranks = Rank.ranks
 let zip x y =
   let n = Array.length x in
   let m = Array.length y in
-  if m <> n then invalidArg "zip: array lengths not equal %d %d" n m
+  if m <> n then invalid_arg ~f:"zip" "array lengths not equal %d %d" n m
   else Array.mapi (fun i x -> x, y.(i)) x
 
 let unzip arr = Array.map fst arr, Array.map snd arr

--- a/src/lib/util/oml_util.ml
+++ b/src/lib/util/oml_util.ml
@@ -23,7 +23,15 @@ type iterative_failure_reason =
 
 exception Iteration_failure of string * iterative_failure_reason
 
-let invalidArg fmt = Printf.ksprintf (fun s -> raise (Invalid_argument s)) fmt
+let invalid_arg ?m ?f fmt =
+  let p =
+    match m, f with
+    | None, None          -> ""
+    | (Some m), None      -> m ^ ": "
+    | None, (Some f)      -> f ^ ": "
+    | (Some m), (Some f)  -> Printf.sprintf "%s.%s:" m f
+  in
+  Printf.ksprintf (fun s -> raise (Invalid_argument (p ^ s))) fmt
 
 let pi = 4. *. atan 1.
 

--- a/src/lib/util/util.mli
+++ b/src/lib/util/util.mli
@@ -27,7 +27,7 @@ type iterative_failure_reason =
 (** The exception raised when an iterative function fails to converge. *)
 exception Iteration_failure of string * iterative_failure_reason
 
-val invalidArg : ('a, unit, string, 'b) format4 -> 'a
+val invalid_arg : ?m:string -> ?f:string -> ('a, unit, string, 'b) format4 -> 'a
 
 (** 3.14159265358979312  *)
 val pi : float


### PR DESCRIPTION
Give more power about specifying errors. I'm not ready to convert all partial functions to use an option or result type (not certain if we'll go that route), but wanted more capabilities with reporting errors.
@struktured or @ihodes  any opinions?
