### PR TITLE
Add a pin command to dsfo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ all: build
 
 # This should be called something else.
 setup:
+	opam pin add dsfo git://github.com/rleonid/dsfo
 	opam install $(PACKAGES_INSTALL)
 
 oml.cmxa:


### PR DESCRIPTION
So that `make setup` is robust. Fixes #158 
