### PR TITLE
Use optional args in descriptive

### DIFF
--- a/src/lib/online_t.ml
+++ b/src/lib/online_t.ml
@@ -50,7 +50,7 @@ let () =
     in
   let compare_against_descriptive rs data =
     let n = Array.length data in
-    let dv = D.unbiased_var data in
+    let dv = D.var ~biased:false data in
     let ds = data |> Array.map (fun x-> x *. x) |> Array.sumf in
     (*Printf.printf "%f vs %f \n" rs.sum_sq ds; *)
     rs.size = n &&

--- a/src/lib/stats/descriptive.ml
+++ b/src/lib/stats/descriptive.ml
@@ -40,9 +40,13 @@ let median arr =
   else sorted.(m)
 
 let var ?population_mean ?(biased=false) arr =
-  let m = match population_mean with | Some m -> m | None -> mean arr in
+  let m, known_mean =
+    match population_mean with
+    | Some m -> m, true
+    | None -> mean arr, false
+  in
   let v = mean (Array.map (fun x -> (x -. m) *. (x -. m)) arr) in
-  if biased then v else
+  if known_mean || biased then v else
     let n = float (Array.length arr) in
     (n /. (n -.  1.0)) *. v
 

--- a/src/lib/stats/descriptive.ml
+++ b/src/lib/stats/descriptive.ml
@@ -46,6 +46,9 @@ let var ?population_mean ?(biased=false) arr =
     let n = float (Array.length arr) in
     (n /. (n -.  1.0)) *. v
 
+let sd ?population_mean ?(biased=false) arr =
+  sqrt (var ?population_mean ~biased arr)
+
 let covariance x y =
   let x_mean = mean x in
   let y_mean = mean y in
@@ -65,7 +68,7 @@ let moment n arr =
   mean (Array.map (fun x -> (x -. m) ** p) arr)
 
 let skew arr =
-  let std = sqrt (var ~biased:true arr) in
+  let std = sd ~biased:true arr in
   (moment 3 arr) /. (std ** 3.0)
 
 let unbiased_skew arr =
@@ -150,7 +153,7 @@ let unbiased_summary arr =
   ; min      = Array.min arr
   ; max      = Array.max arr
   ; mean     = mean arr
-  ; std      = sqrt (var arr)
+  ; std      = sd arr
   ; var      = v
   ; skew     = s, sc
   ; kurtosis = k, kc

--- a/src/lib/stats/descriptive.ml
+++ b/src/lib/stats/descriptive.ml
@@ -39,15 +39,13 @@ let median arr =
   then (sorted.(m - 1) +. sorted.(m)) /. 2.0
   else sorted.(m)
 
-let population_var m arr =
+let var ?population_mean arr =
+  let m = match population_mean with | Some m -> m | None -> mean arr in
   mean (Array.map (fun x -> (x -. m) *. (x -. m)) arr)
 
-let var arr =
-  population_var (mean arr) arr
-
-let unbiased_var arr =
+let unbiased_var ?population_mean  arr =
   let n = float (Array.length arr) in
-  (n /. (n -.  1.0)) *. (var arr)
+  (n /. (n -.  1.0)) *. (var ?population_mean arr)
 
 let covariance x y =
   let x_mean = mean x in

--- a/src/lib/stats/descriptive.mli
+++ b/src/lib/stats/descriptive.mli
@@ -36,16 +36,20 @@ val median : float array -> float
 
 (** Spread. *)
 
-(** [var data] returns the sample variance of [data]. *)
-val var : float array -> float
+(** [var data] returns the sample variance of [data].
+
+    @param population_mean allows you to calculate the variance against a known
+           population mean, and uses the {{!val:mean}sample mean} if not
+           specified. *)
+val var : ?population_mean:float -> float array -> float
 
 (** [unbiased_var] returns the unbiased variance of [data] via Bessel's
-    correction; ie. divinding by [n - 1]. *)
-val unbiased_var : float array -> float
+    correction; ie. divinding by [n - 1].
 
-(** [population_var mean data] computes the variance of data when you know the
-  population [mean]. *)
-val population_var : float -> float array -> float
+    @param population_mean allows you to calculate the variance against a known
+           population mean, and uses the {{!val:mean}sample mean} if not
+           specified. *)
+val unbiased_var : ?population_mean:float -> float array -> float
 
 (* Between two random variables.*)
 

--- a/src/lib/stats/descriptive.mli
+++ b/src/lib/stats/descriptive.mli
@@ -39,13 +39,18 @@ val median : float array -> float
 (** [var data] returns the sample variance of [data].
 
     @param biased By default the variance calculation is unbiased, via Bessel's
-           correction (dividing by [n - 1]) setting the parameter to true will
+           correction (dividing by [n - 1]), setting the parameter to true will
            divide by [n] instead.
 
     @param population_mean allows you to calculate the variance against a known
            population mean, and uses the {{!val:mean}sample mean} if not
            specified. *)
 val var : ?population_mean:float -> ?biased:bool -> float array -> float
+
+(** [sd data] returns the sample standard deviation of [data].
+    Shorthand for to [sqrt (var data)]. See {{!val:var}var} for information
+    about optional args.*)
+val sd : ?population_mean:float -> ?biased:bool -> float array -> float
 
 (* Between two random variables.*)
 

--- a/src/lib/stats/descriptive.mli
+++ b/src/lib/stats/descriptive.mli
@@ -61,8 +61,18 @@ val sd : ?population_mean:float -> ?biased:bool -> float array -> float
     reverse relationship (smaller with larger and vice versa). While values
     close to 0.0 indicate no relationship.
 
+    @param biased By default the covariance calculation is unbiased, via
+           Bessel's correction (dividing by [n - 1]), setting the parameter to
+           true will divide by [n] instead.
+
+    @param population_means allows you to calculate the covariance against
+           known population means, and uses the {{!val:mean}sample mean} if
+           not specified. Setting this will ignore the [biased] parameter as it
+           does not apply.
+
     @raise Invalid_argument if the size of [x] doesn't equal the size of [y]. *)
-val covariance : float array -> float array -> float
+val covariance : ?population_means:(float * float) -> ?biased:bool ->
+  float array -> float array -> float
 
 (** [correlation x y] returns the Pearson correlation coefficient of [x] and
     [y]. This is normalized sample covariance.
@@ -71,7 +81,7 @@ val covariance : float array -> float array -> float
 val correlation : float array -> float array -> float
 
 (** [autocorrelation lag data] computes the correlation of [data] with itself
-  offset by [lag].  *)
+    offset by [lag].  *)
 val autocorrelation : int -> float array -> float
 
 (* Higher moments.*)

--- a/src/lib/stats/descriptive.mli
+++ b/src/lib/stats/descriptive.mli
@@ -38,18 +38,14 @@ val median : float array -> float
 
 (** [var data] returns the sample variance of [data].
 
-    @param population_mean allows you to calculate the variance against a known
-           population mean, and uses the {{!val:mean}sample mean} if not
-           specified. *)
-val var : ?population_mean:float -> float array -> float
-
-(** [unbiased_var] returns the unbiased variance of [data] via Bessel's
-    correction; ie. divinding by [n - 1].
+    @param biased By default the variance calculation is unbiased, via Bessel's
+           correction (dividing by [n - 1]) setting the parameter to true will
+           divide by [n] instead.
 
     @param population_mean allows you to calculate the variance against a known
            population mean, and uses the {{!val:mean}sample mean} if not
            specified. *)
-val unbiased_var : ?population_mean:float -> float array -> float
+val var : ?population_mean:float -> ?biased:bool -> float array -> float
 
 (* Between two random variables.*)
 

--- a/src/lib/stats/descriptive.mli
+++ b/src/lib/stats/descriptive.mli
@@ -81,29 +81,27 @@ val moment : int -> float array -> float
 (** [skew data] computes the sample skew of [data] (Fisher-Pearson's moment
     coefficient of skewness), which is a measure of asymmetry. For unimodal
     data negative values indicate that the left tail is longer in relation
-    to the right.*)
-val skew : float array -> float
+    to the right.
 
-(** [unbiased_skew data] adjusts the skew calculation to take into account
-    sample size.
-
-    The adjustments are chosen to prefer smaller mean squared error for small
-    samples on non-normal distributions. See "Comparing measures of sample
-    skewness and kurtosis" Joanes 1997, for details.  *)
-val unbiased_skew : float array -> float
+    @param biased The default skew calculation is adjusted to take into
+           account sample size. The adjustments are chosen to prefer smaller
+           mean squared error for small samples on non-normal distributions
+           (See "Comparing measures of sample skewness and kurtosis" Joanes
+           1997, for details). Set this parameter to true to ignore these
+           adjustments.  *)
+val skew : ?biased:bool -> float array -> float
 
 (** [kurtosis data] computes the sample kurtosis of [data]. This is a
     measure of the 'peakedness' vs 'tailness' of a distribution. It is adjusted
-    so that a normal distribution will have kurtosis of 0. *)
-val kurtosis : float array -> float
+    so that a normal distribution will have kurtosis of 0.
 
-(** [unbiased_kurtosis data] adjusts the kurtosis calculation to take into
-    account sample size.
-
-    The adjustments are chosen to prefer smaller mean squared error for small
-    samples on non-normal distributions. See "Comparing measures of sample
-    skewness and kurtosis" Joanes 1997, for details.  *)
-val unbiased_kurtosis : float array -> float
+    @param biased The default kurtosis calculation is adjusted to take into
+           account sample size. The adjustments are chosen to prefer smaller
+           mean squared error for small samples on non-normal distributions
+           (See "Comparing measures of sample skewness and kurtosis" Joanes
+           1997, for details). Set this parameter to true to ignore these
+           adjustments.*)
+val kurtosis : ?biased:bool -> float array -> float
 
 (* Error of measurements. *)
 
@@ -166,8 +164,12 @@ type summary =
   ; kurtosis : float * kurtosis_classification
   }
 
-(** [unbiased_summary data] summarizes [data] into a [summary]. *)
-val unbiased_summary : float array -> summary
+(** [summary data] summarizes [data] into a [summary].
+
+    @param biased By default all of the statistics are {i unbiased} (sample size
+           adjustments are made), set this parameter to true to get the regular
+           biased calculations. *)
+val summary : ?biased:bool -> float array -> summary
 
 (** [histogram data width_setting] group [data] into a specific number of buckets
     of given width (according to [width_setting]:

--- a/src/lib/stats/descriptive.mli
+++ b/src/lib/stats/descriptive.mli
@@ -44,7 +44,8 @@ val median : float array -> float
 
     @param population_mean allows you to calculate the variance against a known
            population mean, and uses the {{!val:mean}sample mean} if not
-           specified. *)
+           specified. Setting this will ignore the [biased] parameter as it
+           does not apply.*)
 val var : ?population_mean:float -> ?biased:bool -> float array -> float
 
 (** [sd data] returns the sample standard deviation of [data].

--- a/src/lib/stats/descriptive_t.ml
+++ b/src/lib/stats/descriptive_t.ml
@@ -75,13 +75,13 @@ let () =
     (fun () -> Assert.equalf (var ~biased:true sample_data) 2.0);
 
   add_random_test
-    ~title:"Variance with population mean is just mean variance."
-    (test_data 1e8)
-    (fun data ->
+    ~title:"Variance with population mean is just biased mean variance."
+    Gen.(zip2 (test_data 1e8) bool)
+    (fun (data, biased) ->
       let population_mean = mean data in
-      (var ~population_mean data) = var data)
+      (* testing that we're ignoring 'biased' once population_mean is set. *)
+      (var ~population_mean ~biased data) = var ~biased:true data)
     Spec.([just_postcond_pred is_true]);
-
 
   add_random_test
     ~title:"Unbiased variance is bigger than var."

--- a/src/lib/stats/descriptive_t.ml
+++ b/src/lib/stats/descriptive_t.ml
@@ -65,7 +65,7 @@ let () =
     Spec.([just_postcond_pred is_true]);
 
   add_simple_test ~title:"Population var for small data set."
-    (fun () -> Assert.equalf (population_var 3.0 sample_data) 2.0);
+    (fun () -> Assert.equalf (var ~population_mean:3.0 sample_data) 2.0);
 
   add_simple_test ~title:"Var for small data set."
     (fun () -> Assert.equalf (var sample_data) 2.0);
@@ -74,8 +74,8 @@ let () =
     ~title:"Population_var is just mean var."
     (test_data 1e8)
     (fun data ->
-      let m = mean data in
-      (population_var m data) = var data)
+      let population_mean = mean data in
+      (var ~population_mean data) = var data)
     Spec.([just_postcond_pred is_true]);
 
   add_simple_test ~title:"Unbiased_var for small data set."

--- a/src/lib/stats/descriptive_t.ml
+++ b/src/lib/stats/descriptive_t.ml
@@ -129,19 +129,20 @@ let () =
     (fun data -> moment 2 data = var ~biased:true data)
     Spec.([just_postcond_pred is_true]);
 
-  add_simple_test ~title:"Skew for small data set."
+
+  add_simple_test ~title:"Unbiased skew for small data set."
     (fun () -> Assert.equalf (skew sample_data) 0.0);
 
-  add_simple_test ~title:"Unbiased_skew for small data set."
-    (fun () -> Assert.equalf (unbiased_skew sample_data) 0.0);
-
-  add_simple_test ~title:"Kurtosis for small data set."
-    (fun () -> Assert.equalf (kurtosis sample_data) (-1.3));
+  add_simple_test ~title:"Biased Skew for small data set."
+    (fun () -> Assert.equalf (skew ~biased:true sample_data) 0.0);
 
   let float_eq d = fun x y -> not (Util.significantly_different_from ~d x y) in
-  add_simple_test ~title:"Unbiased_kurtosis for small data set."
+  add_simple_test ~title:"Unbiased Kurtosis for small data set."
     (fun () -> Assert.equalf ~eq:(float_eq 1e-15) (* rounding error :( *)
-                (unbiased_kurtosis sample_data) (-1.2));
+                (kurtosis sample_data) (-1.2));
+  add_simple_test ~title:"Biased Kurtosis for small data set."
+    (fun () -> Assert.equalf (kurtosis ~biased:true sample_data) (-1.3));
+
 
   add_random_test
     ~title:"Variance scales by square."
@@ -199,18 +200,18 @@ let () =
 
   (* Just a regression test to make sure we don't break the 1-1. *)
   add_random_test
-    ~title:"Unbiased_summary is just that."
+    ~title:"summary is just that."
     (test_data 1e8)
     (fun data ->
-      let s = unbiased_summary data in
+      let s = summary data in
       s.size      = Array.length data &&
       s.min       = Array.min data &&
       s.max       = Array.max data &&
       s.mean      = mean data &&
-      s.std       = sd ~biased:false data &&
-      s.var       = var ~biased:false data &&
-      s.skew      = (unbiased_skew data, classify_skew data) &&
-      s.kurtosis  = (unbiased_kurtosis data, classify_kurtosis data))
+      s.std       = sd data &&
+      s.var       = var data &&
+      s.skew      = (skew data, classify_skew data) &&
+      s.kurtosis  = (kurtosis data, classify_kurtosis data))
     Spec.([just_postcond_pred is_true]);
 
   add_random_test

--- a/src/lib/stats/descriptive_t.ml
+++ b/src/lib/stats/descriptive_t.ml
@@ -168,7 +168,7 @@ let () =
     ~title:"Skew and kurtosis (and their statistics) are scale invariant."
     (test_data 1e8)
     (fun data ->
-      let std   = sqrt (var data) in
+      let std   = sd data in
       let sk    = skew data in
       let ku    = kurtosis data in
       let sks   = skew_statistic data in
@@ -207,7 +207,7 @@ let () =
       s.min       = Array.min data &&
       s.max       = Array.max data &&
       s.mean      = mean data &&
-      s.std       = sqrt (var ~biased:false data) &&
+      s.std       = sd ~biased:false data &&
       s.var       = var ~biased:false data &&
       s.skew      = (unbiased_skew data, classify_skew data) &&
       s.kurtosis  = (unbiased_kurtosis data, classify_kurtosis data))

--- a/src/lib/stats/hypothesis_test.ml
+++ b/src/lib/stats/hypothesis_test.ml
@@ -85,7 +85,7 @@ let mean_t_test population_mean hypothesis arr =
   let m = mean arr in
   let d = Array.length arr in
   let nf = float d in
-  let sd = sqrt (var arr) in
+  let sd = sd arr in
   let error = sd /. (sqrt nf) in
   let diff  = m -. population_mean in
   t_test hypothesis ~degrees_of_freedom:(d - 1) ~diff ~error

--- a/src/lib/stats/hypothesis_test.ml
+++ b/src/lib/stats/hypothesis_test.ml
@@ -85,7 +85,7 @@ let mean_t_test population_mean hypothesis arr =
   let m = mean arr in
   let d = Array.length arr in
   let nf = float d in
-  let sd = sqrt (unbiased_var arr) in
+  let sd = sqrt (var arr) in
   let error = sd /. (sqrt nf) in
   let diff  = m -. population_mean in
   t_test hypothesis ~degrees_of_freedom:(d - 1) ~diff ~error
@@ -98,8 +98,8 @@ let means_same_variance_test hypothesis arr1 arr2 =
     let nf2 = float n2 in
     let df1 = nf1 -. 1. in
     let df2 = nf2 -. 1. in
-    let v1 = unbiased_var arr1 in
-    let v2 = unbiased_var arr2 in
+    let v1 = var arr1 in
+    let v2 = var arr2 in
     let vp = Float.((v1 * df1 + v2 * df2) / (df1 + df2)) in
     let f  = Float.( 1. / nf1 + 1. / nf2) in
     sqrt (vp *. f)
@@ -119,8 +119,8 @@ let means_different_variance_test hypothesis arr1 arr2 =
   let n2 = Array.length arr2 in
   let nf1 = float n1 in
   let nf2 = float n2 in
-  let w1 = unbiased_var arr1 /. nf1 in
-  let w2 = unbiased_var arr2 /. nf2 in
+  let w1 = var arr1 /. nf1 in
+  let w2 = var arr2 /. nf2 in
   let vw = w1 +. w2 in
   let df1 = nf1 -. 1. in
   let df2 = nf2 -. 1. in
@@ -137,8 +137,8 @@ let means_different_variance_test hypothesis arr1 arr2 =
   t_test hypothesis ~degrees_of_freedom ~diff ~error
 
 let variance_ratio_test arr1 arr2 =
-  let v1 = unbiased_var arr1 in
-  let v2 = unbiased_var arr2 in
+  let v1 = var arr1 in
+  let v2 = var arr2 in
   let dg1 = float (Array.length arr1 - 1) in
   let dg2 = float (Array.length arr2 - 1) in
   let f, d1, d2 =


### PR DESCRIPTION
In working with `R` for a bit I've grown accustomed to a shorter syntax for these common operators. The effective interface change is:

``` Diff
< val var : float array -> float
< val unbiased_var : float array -> float
< val population_var : float -> float array -> float
> val var : ?population_mean:float -> ?biased:bool -> float array -> float
> val sd : ?population_mean:float -> ?biased:bool -> float array -> float
< val covariance : float array -> float array -> float
> val covariance : ?population_means:(float * float) -> ?biased:bool ->
>   float array -> float array -> float
< val skew : float array -> float
< val unbiased_skew : float array -> float
> val skew : ?biased:bool -> float array -> float
< val kurtosis : float array -> float
< val unbiased_kurtosis : float array -> float
> val kurtosis : ?biased:bool -> float array -> float
< val unbiased_summary : float array -> summary
> val summary : ?biased:bool -> float array -> summary
```
