### PR TITLE
Added Alias method for sampling multinomial

### DIFF
--- a/src/lib/stats/sampling.ml
+++ b/src/lib/stats/sampling.ml
@@ -62,14 +62,16 @@ let normal ?seed ~mean ~std () =
   let rsn = normal_std ?seed () in
   (fun () -> std *. (rsn ()) +. mean)
 
-(** Alias method for sampling from a categorical distribution.
+(** {{:http://www.keithschwarz.com/darts-dice-coins} Alias method} for
+    sampling from a Categorical distribution.
 
     The method allows to generate a sample in costant time after a
     linear time preprocessing of the probabilities array. *)
 module Alias =
   struct
     type t =
-      { probs: float array
+      { n : int
+      ; probs: float array
       ; alias: int array
       }
 
@@ -104,15 +106,15 @@ module Alias =
           partition weights (succ i) (small, i::large)
       in
 
-      let (small, large) = partition weights 0 ([], [])
-      and probs = Array.make n 0.0
-      and alias = Array.make n 0 in begin
+      let (small, large) = partition weights 0 ([], []) in
+      let probs = Array.make n 0.0 in
+      let alias = Array.make n 0 in begin
         iter weights probs alias (small, large);
-        { probs; alias }
+        { n; probs; alias }
       end
 
-    let sample { probs; alias } r =
-      let i = Random.State.int r (Array.length alias) in
+    let sample { n; probs; alias } r =
+      let i = Random.State.int r n in
       if (Random.State.float r 1.0 < probs.(i)) then i else alias.(i)
   end
 

--- a/src/lib/stats/sampling.ml
+++ b/src/lib/stats/sampling.ml
@@ -118,20 +118,20 @@ module Alias =
       if (Random.State.float r 1.0 < probs.(i)) then i else alias.(i)
   end
 
-let multinomial ?seed weights =
+let categorical ?seed weights =
   if not (Array.all (within (Open 0.0, Closed 1.0)) weights) then
-    invalid_arg ~f:"multinomial" "weights must be within (0, 1]"
+    invalid_arg ~f:"categorical" "weights must be within (0, 1]"
   else
     let sum = Array.sumf weights in
     if significantly_different_from 1.0 sum then
-      invalid_arg ~f:"multinomial" "weights must sum to 1 (got: %.2f)" sum
+      invalid_arg ~f:"categorical" "weights must sum to 1 (got: %.2f)" sum
     else
       let r = init seed
       and alias = Alias.create weights in
       (fun () -> Alias.sample alias r)
 
 let softmax ?seed ?temperature weights =
-  multinomial ?seed (F.softmax ?temperature weights)
+  categorical ?seed (F.softmax ?temperature weights)
 
 
 module Poly =
@@ -140,10 +140,10 @@ module Poly =
       let f = uniform_i ?seed (Array.length elems) in
       fun () -> elems.(f())
 
-    let multinomial ?seed elems weights =
+    let categorical ?seed elems weights =
       if (Array.length elems != Array.length weights) then
         raise (Invalid_argument "weights") else
-          let f = multinomial ?seed weights in
+          let f = categorical ?seed weights in
           fun () -> elems.(f())
 
     let softmax ?seed ?temperature elems weights =

--- a/src/lib/stats/sampling.mli
+++ b/src/lib/stats/sampling.mli
@@ -46,14 +46,14 @@ val normal : ?seed:int array -> mean:float -> std:float -> unit -> float generat
 (** [normal_std seed ()] is equivalent to [normal seed ~mean:0.0 ~std:1.0 ()].*)
 val normal_std : ?seed:int array -> unit -> float generator
 
-(** [multinomial ?seed weights] creates a generator that will return an integer
-    representating the ith element from the Multinomial distribution given by
+(** [categorical ?seed weights] creates a generator that will return an integer
+    representating the ith element from the Categorical distribution given by
     a [weights] vector which sums to [1].
 
     @raise Invalid_argument if [weights] do not sum to [1.0] (this is checked
      using [Util.significantly_different_from]) or any individual weight is not
      in \[[0,1]). *)
-val multinomial : ?seed:int array -> float array -> int generator
+val categorical : ?seed:int array -> float array -> int generator
 
 (** [softmax ?seed ?temperature weights] creates a generator that will return an integer
     representating the ith element from the softmax distribution given by
@@ -71,13 +71,13 @@ module Poly :
         @raise Invalid_argument if the given element array is empty. *)
     val uniform : ?seed:int array -> 'a array -> 'a generator
 
-    (** [multinomial ?seed elems weights] creates a generator will sample from
-        the [elems] array using Multinomial distribution given by
+    (** [categorical ?seed elems weights] creates a generator will sample from
+        the [elems] array using Categorical distribution given by
         a [weights] vector which sums to [1].
 
         @raise Invalid_argument if [weights] do not sum to [1.0] or
         the length of the [elems] and [weights] arrays are not equal. *)
-    val multinomial : ?seed:int array -> 'a array -> float array -> 'a generator
+    val categorical : ?seed:int array -> 'a array -> float array -> 'a generator
 
     (** [softmax ?seed ?temperature elems weights] creates a generator that will
         sample from the [elems] array using the softmax distribution given by

--- a/src/lib/stats/sampling_t.ml
+++ b/src/lib/stats/sampling_t.ml
@@ -114,10 +114,10 @@ let () =
   (* I think with P=0.998 this test passes, but occasionally the restriction
      that sum = 1.0 might trip, especially if the size of the array grows. *)
   add_partial_random_test
-    ~title:"Multinomial obeys bounds."
+    ~title:"Categorical obeys bounds."
     Gen.(zip2 seed sometimes_good_weights)
     (fun (seed, (_, weights)) ->
-      let mm = multinomial ?seed weights in
+      let mm = categorical ?seed weights in
       let _  = Array.init samples (fun _ -> mm ()) in
       true)
     Spec.([ good_weights     ==> is_result is_true
@@ -140,11 +140,11 @@ let () =
   let add_simple_test = Test.add_simple_test_group "Sampling" in
 
   add_simple_test
-    ~title:"Multinomial is correct."
+    ~title:"Categorical is correct."
     (fun () ->
        let n_samples = 10000 in
        let weights = [|0.15; 0.6; 0.25|] in
-       let mm = multinomial weights in
+       let mm = categorical weights in
        let counts = Array.make (Array.length weights) 0 in begin
          for _s = 0 to n_samples - 1 do
            let i = mm () in

--- a/src/lib/stats/sampling_t.ml
+++ b/src/lib/stats/sampling_t.ml
@@ -134,7 +134,25 @@ let () =
       true)
     Spec.([ (fun (_,arr) -> arr <> [||]) ==> is_result is_true
           ; (fun (_,arr) -> arr =  [||]) ==> is_exception is_invalid_arg
-          ]);
+          ])
 
-  ()
+let () =
+  let add_simple_test = Test.add_simple_test_group "Sampling" in
 
+  add_simple_test
+    ~title:"Multinomial is correct."
+    (fun () ->
+       let n_samples = 10000 in
+       let weights = [|0.15; 0.6; 0.25|] in
+       let mm = multinomial weights in
+       let counts = Array.make (Array.length weights) 0 in begin
+         for _s = 0 to n_samples - 1 do
+           let i = mm () in
+           counts.(i) <- counts.(i) + 1
+         done;
+
+         Array.iteri (fun i count ->
+             Assert.equal_float ~eps:1e-2 weights.(i)
+               (float count /. float n_samples))
+           counts
+       end)


### PR DESCRIPTION
Unlike the previous cumsum implementation, [the Alias method](http://www.keithschwarz.com/darts-dice-coins) generates a value in constant time.

I also wanted to discuss the naming of `multinomial`. The sampling procedure looks like it samples from a discrete (aka [Categorical](https://en.wikipedia.org/wiki/Categorical_distribution)) distribution.
