### PR TITLE
Expose degenerate propagation

### DIFF
--- a/src/stats/oml_measures.ml
+++ b/src/stats/oml_measures.ml
@@ -19,9 +19,6 @@
 open MoreLabels
 module List = ListLabels
 
-let invalid_arg ~f fmt =
-  Oml_util.invalid_arg ~m:"Measure" ~f fmt
-
 let normal_kl_divergence ?d ~p_mean ~p_sigma ~q_mean ~q_sigma () =
   let open Oml_util in
   let p_sigma_degen = not @@ significantly_different_from ?d p_sigma 0.0 in
@@ -48,7 +45,9 @@ let discrete_kl_divergence ?d (type a) ~(p : (a * 'b) list) ~q () =
   let module S = Set.Make(O) in
   let module M = Map.Make(O) in
   let invalid_if b s =
-    if b then invalid_arg ~f:"discrete_kl_divergence" "%s" s else ()
+    if b then
+      invalid_arg ~m:"Measure" ~f:"discrete_kl_divergence" "%s" s
+    else ()
   in
   let not_within_prob_range p = p < 0. || 1. < p in
   (* TODO: We should probably have different strategies for aggregating keys.

--- a/src/stats/oml_measures.ml
+++ b/src/stats/oml_measures.ml
@@ -22,10 +22,10 @@ module List = ListLabels
 let invalid_arg ~f fmt =
   Oml_util.invalid_arg ~m:"Measure" ~f fmt
 
-let normal_kl_divergence ~p_mean ~p_sigma ~q_mean ~q_sigma =
+let normal_kl_divergence ?d ~p_mean ~p_sigma ~q_mean ~q_sigma () =
   let open Oml_util in
-  let p_sigma_degen = not @@ significantly_different_from p_sigma 0.0 in
-  let q_sigma_degen = not @@ significantly_different_from q_sigma 0.0 in
+  let p_sigma_degen = not @@ significantly_different_from ?d p_sigma 0.0 in
+  let q_sigma_degen = not @@ significantly_different_from ?d q_sigma 0.0 in
   if p_sigma_degen || q_sigma_degen then infinity else
   let mean_diff = p_mean -. q_mean in
   let mean_diff_sq = mean_diff *. mean_diff in
@@ -41,7 +41,7 @@ let normal_kl_divergence ~p_mean ~p_sigma ~q_mean ~q_sigma =
 
   TODO: allow parameterization over different logs, ex. nats vs bits.
 *)
-let discrete_kl_divergence (type a) ~(p : (a * 'b) list) ~q =
+let discrete_kl_divergence ?d (type a) ~(p : (a * 'b) list) ~q () =
   let open Printf in
   let open Oml_util in
   let module O = struct type t = a let compare = compare end in
@@ -70,14 +70,14 @@ let discrete_kl_divergence (type a) ~(p : (a * 'b) list) ~q =
       ~f:(across_distribution_assoc "P")
   in
   let ks = Kahan.sum s in
-  invalid_if (significantly_different_from ks 1.)
+  invalid_if (significantly_different_from ?d ks 1.)
     (sprintf "P probabilities don't sum to 1: %f" ks);
   let keys, mq, s =
     List.fold_left q ~init:(keys, M.empty, Kahan.empty)
       ~f:(across_distribution_assoc "Q")
   in
   let ks = Kahan.sum s in
-  invalid_if (significantly_different_from ks 1.)
+  invalid_if (significantly_different_from ?d ks 1.)
     (sprintf "Q probabilities don't sum to 1: %f" ks);
   let k_up_with_dg_c = Kahan.update_with_degenerate_check in
   S.fold keys

--- a/src/stats/oml_measures.ml
+++ b/src/stats/oml_measures.ml
@@ -79,6 +79,7 @@ let discrete_kl_divergence (type a) ~(p : (a * 'b) list) ~q =
   let ks = Kahan.sum s in
   invalid_if (significantly_different_from ks 1.)
     (sprintf "Q probabilities don't sum to 1: %f" ks);
+  let k_up_with_dg_c = Kahan.update_with_degenerate_check in
   S.fold keys
     ~init:Kahan.empty (* TODO: is the accuracy warrented? *)
     ~f:(fun key s ->
@@ -87,7 +88,7 @@ let discrete_kl_divergence (type a) ~(p : (a * 'b) list) ~q =
           | 0.                      -> s
           | p  ->
               match M.find key mq with
-              | exception Not_found -> Kahan.update s infinity
-              | 0.                  -> Kahan.update s infinity
-              | q                   -> Kahan.update s (p *. log ( p /. q)))
+              | exception Not_found -> k_up_with_dg_c s infinity
+              | 0.                  -> k_up_with_dg_c s infinity
+              | q                   -> k_up_with_dg_c s (p *. log ( p /. q)))
   |> Kahan.sum

--- a/src/stats/oml_measures.mli
+++ b/src/stats/oml_measures.mli
@@ -20,18 +20,25 @@
 (** Provides various measurement functions from statistics and analysis *)
 
 
-val normal_kl_divergence : p_mean:float -> p_sigma:float
-  -> q_mean:float -> q_sigma:float -> float
+val normal_kl_divergence : ?d:float -> p_mean:float -> p_sigma:float ->
+      q_mean:float -> q_sigma:float -> unit -> float
 (** Computes kl divergence of the normal distributions P and Q defined
     given means [p_mean] and [q_mean] and std deviations [p_sigma]
-    and [q_sigma]. Returns infinity for variances near zero. *)
+    and [q_sigma]. Returns infinity for variances near zero.
 
-val discrete_kl_divergence : p:('a * float) list -> q:('a * float) list -> float
+    @param d float can be used to tune the sensitivity of the checks for
+    zero.
+    *)
+
+val discrete_kl_divergence : ?d:float -> p:('a * float) list ->
+      q:('a * float) list -> unit ->  float
 (** [discrete_kl_divergence ~p:p_pdf ~q:q_pdf] Compute the KL divergence from
     [p_pdf] to [q_pdf]. [p_pdf] and [q_pdf] represent discrete probability
     distributions. Please note that this metric is not symmetric and the result
     does {b not} equal [discrete_kl_divergence ~p:q_pdf ~q:p_pdf].
 
+    @param d float can be used to tune the sensitivity of checks that the
+      probabilities sum to 1.
     @raise Invalid_argument if [p_pdf] or [q_pdf] have duplicate events,
       the probabilities are outside the bounds, or they not sum to 1.
     *)

--- a/src/stats/oml_measures.mli
+++ b/src/stats/oml_measures.mli
@@ -16,9 +16,7 @@
    limitations under the License.
 *)
 
-
 (** Provides various measurement functions from statistics and analysis *)
-
 
 val normal_kl_divergence : ?d:float -> p_mean:float -> p_sigma:float ->
       q_mean:float -> q_sigma:float -> unit -> float

--- a/src/stats/oml_measures.mlt
+++ b/src/stats/oml_measures.mlt
@@ -34,7 +34,7 @@ let () =
       let p_sigma = max 0.1 (sqrt @@ abs_float p_mean) in
       let q_sigma = p_sigma in
       let kldiv q_mean = normal_kl_divergence
-        ~p_mean ~q_mean ~p_sigma ~q_sigma in
+        ~p_mean ~q_mean ~p_sigma ~q_sigma () in
       List.fold_left [0.6;0.4;0.25;0.1]
         ~f:(fun (res, kl, l) frac ->
             let delta = (p_mean -. res) *. frac in
@@ -53,7 +53,7 @@ let () =
       let p_mean = p_sigma *. p_sigma in
       let q_mean = p_mean in
       let kldiv q_sigma = normal_kl_divergence
-        ~p_mean ~q_mean ~p_sigma ~q_sigma in
+        ~p_mean ~q_mean ~p_sigma ~q_sigma () in
       List.fold_left [0.6;0.4;0.25;0.1]
         ~f:(fun (res, kl, l) frac ->
               let delta = (p_sigma -. res) *. frac in
@@ -70,7 +70,7 @@ let () =
     (fun () ->
       let fair_die = Array.init 6 (fun i -> i + 1, 1. /. 6.) |> Array.to_list in
       let not_fair = [ (1, 0.1) ; (2, 0.1); (3, 0.1); (4, 0.1); (5, 0.1); (6, 0.5) ] in
-      let kld =  discrete_kl_divergence ~p:fair_die ~q:not_fair in
+      let kld = discrete_kl_divergence ~p:fair_die ~q:not_fair () in
       Assert.equalf kld 0.242585971693640517);
 
   ()

--- a/src/util/oml_kahan.ml
+++ b/src/util/oml_kahan.ml
@@ -24,12 +24,14 @@ let empty = { correction = 0.; sum = 0. }
 let zero = empty
 
 let update t v =
-  if Oml_util_base.is_degenerate t.sum then t else
-    let x  = v -. t.correction in
-    let ns = t.sum +. x in
-    { correction = (ns -. t.sum) -. x
-    ; sum = ns
-    }
+  let x  = v -. t.correction in
+  let ns = t.sum +. x in
+  { correction = (ns -. t.sum) -. x
+  ; sum = ns
+  }
+
+let update_with_degenerate_check t v =
+  if Oml_util_base.is_degenerate t.sum then t else update t v
 
 let ( + ) = update
 

--- a/src/util/oml_kahan.mli
+++ b/src/util/oml_kahan.mli
@@ -26,6 +26,11 @@ val zero : t
 (** [update summation value] *)
 val update : t -> float -> t
 
+(** [update_with_degenerate_check summation value]
+    Does not update the sum if it is currently at a degenerate
+    (infinity, neg_infinity or nan) value. *)
+val update_with_degenerate_check : t -> float -> t
+
 (** [update summation value] *)
 val ( + ) : t -> float -> t
 

--- a/src/util/oml_kahan.mlt
+++ b/src/util/oml_kahan.mlt
@@ -19,17 +19,18 @@ open Test_utils
 
 let () =
   let add_simple_test = Test.add_simple_test_group __MODULE__ in
-  add_simple_test ~title:"Kahan summations keep the first degeneracy"
+  add_simple_test ~title:"Kahan summations keep the first degeneracy when updated with degenerate check."
     (fun () ->
       let is_nan (x : float) = x <> x in
       let e = empty in
-      Assert.is_true (sum (update (update e infinity) nan) = infinity
-                  &&  sum (update (update e infinity) neg_infinity) = infinity
-                  &&  sum (update (update e infinity) 3.4) = infinity
-                  &&  sum (update (update e neg_infinity) nan) = neg_infinity
-                  &&  sum (update (update e neg_infinity) infinity) = neg_infinity
-                  &&  sum (update (update e neg_infinity) (-342.3)) = neg_infinity
-                  &&  (is_nan (sum (update (update e nan) infinity)))
-                  &&  (is_nan (sum (update (update e nan) 0.3)))
-                  &&  (is_nan (sum (update (update e nan) neg_infinity)))));
+      let upwdgc = update_with_degenerate_check in
+      Assert.is_true (sum (upwdgc (upwdgc e infinity) nan) = infinity
+                  &&  sum (upwdgc (upwdgc e infinity) neg_infinity) = infinity
+                  &&  sum (upwdgc (upwdgc e infinity) 3.4) = infinity
+                  &&  sum (upwdgc (upwdgc e neg_infinity) nan) = neg_infinity
+                  &&  sum (upwdgc (upwdgc e neg_infinity) infinity) = neg_infinity
+                  &&  sum (upwdgc (upwdgc e neg_infinity) (-342.3)) = neg_infinity
+                  &&  (is_nan (sum (upwdgc (upwdgc e nan) infinity)))
+                  &&  (is_nan (sum (upwdgc (upwdgc e nan) 0.3)))
+                  &&  (is_nan (sum (upwdgc (upwdgc e nan) neg_infinity)))));
   ()


### PR DESCRIPTION
This PR deals with 2 issues.

First off, when performing summation with the Kahan correction, by default we want to propagate float degenerate values according to the standard (once a `nan` always a `nan`). But in some cases we want to have just keep the first degenerate value we encounter as it can be more informative in certain context (ex. computing KL-divergence). I see this as a step towards generalizing this behavior in other cases.

The second issue is that it exposes the optional `d` parameter which is used for float comparisons further upstream in the KL divergence calculations. I could imagine us having to expose this parameter in many more interface exposed functions (such as in the distributions) as float comparison is pretty central to the logic of these algorithms. 